### PR TITLE
update markdown manager

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,2 @@
 theme: jekyll-theme-slate
+markdown : GFM


### PR DESCRIPTION
Changed default markdown to GFM due to table conflicts. similar issue https://github.com/pages-themes/cayman/issues/82

previous:
![image](https://user-images.githubusercontent.com/79627254/225542782-7ee496cd-5322-4d99-ab65-34310b3f5b23.png)

updeated:
![image](https://user-images.githubusercontent.com/79627254/225542912-1970e8ac-b42d-4140-bda5-74e674887097.png)

